### PR TITLE
Switch image upload to url string field.

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -26,6 +26,7 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
+# REMOVE AFTER MIGRATIONS
 gem 'paperclip'
 gem 'pusher'
 # gem 'haml-rails'

--- a/server/app/controllers/arts_controller.rb
+++ b/server/app/controllers/arts_controller.rb
@@ -9,7 +9,7 @@ class ArtsController < ApplicationController
   end
 
   def create
-    @art = Art.create art_params  
+    @art = Art.create art_params
     respond_to do |format|
       format.json { render json: @art.to_json }
       format.html 
@@ -41,7 +41,8 @@ private
       :title,
       :description,
       :artist,
-      :dimensions
+      :dimensions,
+      :image_url
     )
   end
 end

--- a/server/app/models/art.rb
+++ b/server/app/models/art.rb
@@ -1,5 +1,3 @@
 class Art < ActiveRecord::Base
-  has_attached_file :image, :styles => { large: "1600x1600>", medium: "300x300>" }, default_url: "/images/:style/missing.png"
-  validates_attachment_content_type :image, :content_type => /\Aimage\/.*\Z/
   has_many :auctions, dependent: :destroy
 end

--- a/server/db/migrate/20150220170807_switch_image_to_field_in_arts.rb
+++ b/server/db/migrate/20150220170807_switch_image_to_field_in_arts.rb
@@ -1,0 +1,7 @@
+class SwitchImageToFieldInArts < ActiveRecord::Migration
+  def change
+    # requires Paperclip
+    remove_attachment :arts, :image
+    add_column :arts, :image_url, :string
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -11,19 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150218233217) do
+ActiveRecord::Schema.define(version: 20150220170807) do
 
   create_table "arts", force: :cascade do |t|
-    t.string   "title",              limit: 255
-    t.text     "description",        limit: 65535
-    t.string   "artist",             limit: 255
-    t.string   "dimensions",         limit: 255
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.string   "image_file_name",    limit: 255
-    t.string   "image_content_type", limit: 255
-    t.integer  "image_file_size",    limit: 4
-    t.datetime "image_updated_at"
+    t.string   "title",       limit: 255
+    t.text     "description", limit: 65535
+    t.string   "artist",      limit: 255
+    t.string   "dimensions",  limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.string   "image_url",   limit: 255
   end
 
   create_table "auctions", force: :cascade do |t|

--- a/server/test/controllers/arts_controller_test.rb
+++ b/server/test/controllers/arts_controller_test.rb
@@ -22,7 +22,8 @@ class ArtsControllerTest < ActionController::TestCase
         title: 'The Red Pony',
         description: 'It has a red pony!',
         artist: 'Adam',
-        dimensions: '1in x 30in'
+        dimensions: '1in x 30in',
+        image_url: 'http://www.online-image-editor.com//styles/2014/images/example_image.png'
     }
 
     assert_difference 'Art.count' do
@@ -30,6 +31,14 @@ class ArtsControllerTest < ActionController::TestCase
     end
 
     assert_equal response.code, '200'
+
+    last_art = Art.last
+
+    assert_equal last_art.title, 'The Red Pony'
+    assert_equal last_art.description, 'It has a red pony!'
+    assert_equal last_art.artist, 'Adam'
+    assert_equal last_art.dimensions, '1in x 30in'
+    assert_equal last_art.image_url, 'http://www.online-image-editor.com//styles/2014/images/example_image.png'
   end
 
   test '#update' do


### PR DESCRIPTION
Set up on the Rails end to receive an image url rather than a file upload.

We need paperclip to be in the gemfile to run the migrations.  After everyone runs the migrations, we can remove paperclip.
